### PR TITLE
chore: Fixing errors identified in trial run (2024-05-09)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_zero_division.md
+++ b/.github/ISSUE_TEMPLATE/01_zero_division.md
@@ -1,7 +1,7 @@
 ---
-name: Add Zero Division Exception
+name: 01 - Add Zero Division Exception
 about: Instructions on adding a Zero Division exception to the divide function
-title: "01 Add zero division exception and test"
+title: "Add zero division exception and test"
 labels: enhancement, help wanted
 assignees: ""
 ---
@@ -36,8 +36,10 @@ With the following code which raises a custom exception message.
 ```python
 try:
     return x / y
-except ZeroDivsionError as e:
-    raise e("You can not divide by 0, please choose another value for 'y'.")
+except ZeroDivisionError as e:
+    raise ZeroDivisionError(
+        "You can not divide by 0, please choose another value for 'y'."
+    ) from e
 ```
 
 ### Add a test to check the exception is raised
@@ -46,9 +48,9 @@ Add the following to the `tests/test_arithmetic.py` which checks that the except
 
 ```python
 def test_divide_zero_division_exception() -> None:
-    """Test that a ZeroDivsionError is raised by the divide() function."""
+    """Test that a ZeroDivisionError is raised by the divide() function."""
     with pytest.raises(ZeroDivisionError):
-        divide(2, 0)
+        arithmetic.divide(2, 0)
 ```
 
 ### Save, stage, commit your changes

--- a/.github/ISSUE_TEMPLATE/02_square_root.md
+++ b/.github/ISSUE_TEMPLATE/02_square_root.md
@@ -1,7 +1,7 @@
 ---
-name: Add Square Root Function
+name: 02 - Add Square Root Function
 about: Instructions on adding a Square Root function to the Arithmetic module
-title: "02 Add a square root function and test"
+title: "Add a square root function and test"
 labels: enhancement, help wanted
 assignees: ""
 ---
@@ -57,7 +57,7 @@ def square_root(x):
 Add the following to the `tests/test_arithmetic.py` which checks the correct values are returned that the exception is raised.
 
 ```python
-@pytest.mark.parametrix(
+@pytest.mark.parametrize(
     ("x", "target"),
     [
         pytest.mark(4, 2, id="square root of 4"),

--- a/.github/ISSUE_TEMPLATE/03_zero_division_amend_fixup.md
+++ b/.github/ISSUE_TEMPLATE/03_zero_division_amend_fixup.md
@@ -1,7 +1,7 @@
 ---
-name: Zero Division - Amend and Fixup
+name: 03 - Zero Division - Amend and Fixup
 about: Instructions on amending and fixup the Zero Division branch.
-title: "03 Zero Division Amend and Fixup"
+title: "Zero Division Amend and Fixup"
 labels: enhancement, help wanted
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/04_square_root_amend_fixup.md
+++ b/.github/ISSUE_TEMPLATE/04_square_root_amend_fixup.md
@@ -1,7 +1,7 @@
 ---
-name: Square Root - Amend and Fixup
+name: 04 - Square Root - Amend and Fixup
 about: Instructions on amending and fixup the Zero Division branch.
-title: "03 Square Root Amend and Fixup"
+title: "Square Root Amend and Fixup"
 labels: enhancement, help wanted
 assignees: ""
 ---

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -64,15 +64,3 @@ def test_multiply(x: int | float, y: int | float, expected: int | float) -> None
 def test_divide(x: int | float, y: int | float, expected: int | float) -> None:
     """Test the divide function."""
     assert arithmetic.divide(x, y) == pytest.approx(expected)
-
-
-@pytest.mark.parametrize(  # type: ignore[misc]
-    ("x", "y"),
-    [
-        pytest.param(10, 0, id="Divide by zero"),
-    ],
-)
-def test_divide_zerodivision_error(x: int | float, y: int | float) -> None:
-    """Test ZeroDivision is raised."""
-    with pytest.raises(ZeroDivisionError):
-        arithmetic.divide(x, y)


### PR DESCRIPTION
+ Issue templates name/titles.
+ [Tpyo in template `ZeroDivsionError` > `ZeroDivisionError`](https://github.com/ns-rse/git-collaboration/issues/68#issuecomment-2102625016)
+ [Correct template `arithmetic.divide`](https://github.com/ns-rse/git-collaboration/issues/68#issuecomment-2102627201)
+ [Tpyo `parametrix` > `parametric` in 02_square_root.md](https://github.com/ns-rse/git-collaboration/issues/68#issuecomment-2102626829)
+ [Correct example to raise error to pass pylint/ruff](https://github.com/ns-rse/git-collaboration/issues/68#issuecomment-2102633398)
+ Remove `test_divide_zerodivision_error()` as it is added as part of a challenge.
+ Remove numpydoc-validation from pre-commit hooks as it is meant to be added as part of a challenge.